### PR TITLE
fix tuple indexerror for no rank for genome-shred-to-tax.py

### DIFF
--- a/genome-shred-to-tax.py
+++ b/genome-shred-to-tax.py
@@ -85,7 +85,11 @@ def main():
 
                 for k in lineage_counts:
                     lca = lca_utils.display_lineage(k, truncate_empty=False)
-                    w.writerow((genome, record.name, start, start + args.fragment, lca, k[-1].rank))
+                    try:
+                        lca_rank = k[-1].rank
+                    except IndexError:
+                        lca_rank = "none"
+                    w.writerow((genome, record.name, start, start + args.fragment, lca, lca_rank))
 
                 m += 1
                 min_value = min(mh.get_mins())


### PR DESCRIPTION
This fixes the error:

```
Traceback (most recent call last):
  File "./genome-shred-to-tax.py", line 102, in <module>
    sys.exit(main())
  File "./genome-shred-to-tax.py", line 88, in main
    print(k[-1])
IndexError: tuple index out of range
```

that occurs when the tuple for lca is empty:
```
;;;;;;;
```

There are probably better ways to fix this...but this one worked :)