### PR TITLE
Improvements to reporting to aid in evaluation

### DIFF
--- a/charcoal/Snakefile
+++ b/charcoal/Snakefile
@@ -230,7 +230,8 @@ rule combined_summary:
                       "n_reason_1", "n_reason_2", "n_reason_3",
                       "refsize", "ratio",
                       "clean_bp", "clean_n", "dirty_n", "dirty_bp", "missed_n",
-                      "missed_bp", "taxguessed", "taxprovided",
+                      "missed_bp", "noident_n", "noident_bp",
+                      "taxguessed", "taxprovided",
                       "comment"]
 
             w.writerow(header)

--- a/charcoal/just_taxonomy.py
+++ b/charcoal/just_taxonomy.py
@@ -347,6 +347,9 @@ class ContigsDecontaminator(object):
         """
         reason = 0
 
+        if not contig_mh.get_mins():
+            return ContigInfo.NO_HASH
+
         # get _all_ of the hash taxonomy assignments for this contig
         ctg_assign = gather_assignments(contig_mh.get_mins(), None,
                                         [self.lca_db], self.lin_db)

--- a/charcoal/just_taxonomy.py
+++ b/charcoal/just_taxonomy.py
@@ -400,7 +400,7 @@ class ContigsDecontaminator(object):
         return clean
 
 
-def choose_genome_lineage(lca_genome_lineage, provided_lineage,
+def choose_genome_lineage(lca_genome_lineage, provided_lineage, match_rank,
                           f_ident, f_major, report):
 
     comment = ""
@@ -499,12 +499,13 @@ def main(args):
     provided_lin = ""
     if args.lineage and args.lineage != 'NA':
         provided_lin = args.lineage.split(';')
-        provided_lin = [ LineagePair(rank, name) for (rank, name) in zip(sourmash.lca.taxlist(), provided_lin) ]
+        provided_lin = [ LineagePair(rank, name) for (rank, name) in zip(sourmash.lca.taxlist(), provided_lin) if name.strip() ]
         report(f'Provided lineage from command line:\n   {sourmash.lca.display_lineage(provided_lin)}')
 
     # choose between the lineages
     genome_lineage, comment = choose_genome_lineage(lca_genome_lineage,
                                                     provided_lin,
+                                                    match_rank,
                                                     f_ident, f_major,
                                                     report)
 

--- a/charcoal/just_taxonomy.py
+++ b/charcoal/just_taxonomy.py
@@ -284,6 +284,9 @@ class ContigsDecontaminator(object):
         This method discovers chunks of sequence that belong to other
         lineages.
         """
+        if not contig_mh:
+            return ContigInfo.NO_HASH
+
         threshold_bp = contig_mh.scaled * self.GATHER_THRESHOLD
         results = self.lca_db.gather(sourmash.SourmashSignature(contig_mh),
                                      threshold_bp=threshold_bp)

--- a/charcoal/just_taxonomy.py
+++ b/charcoal/just_taxonomy.py
@@ -293,11 +293,11 @@ class ContigsDecontaminator(object):
         if not utils.is_lineage_match(self.genome_lineage, contig_lineage,
                                       self.match_rank):
             clean=False
-            self.n_reason_3 += 1
+            self.n_reason_1 += 1
             common_kb = contig_mh.count_common(match.minhash) * contig_mh.scaled / 1000
 
             print(f'---- contig {record.name} ({len(record.sequence)/1000:.0f} kb)', file=report_fp)
-            print(f'contig dirty, REASON 3 - gather matches to lineage outside of genome\'s {self.match_rank}', file=report_fp)
+            print(f'contig dirty, REASON 1 - gather matches to lineage outside of genome\'s {self.match_rank}', file=report_fp)
             print(f'   contig gather yields match of {common_kb:.0f} kb to {pretty_print_lineage2(contig_lineage, self.match_rank)}', file=report_fp)
             print(f'   vs genome lineage of {pretty_print_lineage2(self.genome_lineage, self.match_rank)}', file=report_fp)
             print('', file=report_fp)
@@ -365,19 +365,19 @@ class ContigsDecontaminator(object):
             if ctg_lin:
                 bad_rank = ctg_lin[-1].rank
             clean = False
-            self.n_reason_1 += 1
+            self.n_reason_2 += 1
             print(f'\n---- contig {record.name} ({len(record.sequence)/1000:.0f} kb)', file=report_fp)
-            print(f'contig dirty, REASON 1 - contig LCA is above {self.match_rank}\nlca rank is {bad_rank}',
+            print(f'contig dirty, REASON 2 - contig LCA is above {self.match_rank}\nlca rank is {bad_rank}',
                   file=report_fp)
         # second check - is the majority lineage of hashes in this contig
         # outside the match rank?
         elif not utils.is_lineage_match(self.genome_lineage, ctg_lin,
                                         self.match_rank):
             clean = False
-            self.n_reason_2 += 1
+            self.n_reason_3 += 1
             print('', file=report_fp)
             print(f'---- contig {record.name} ({len(record.sequence)/1000:.0f} kb)', file=report_fp)
-            print(f'contig dirty, REASON 2 - contig lineage is not a match to genome\'s {self.match_rank}', file=report_fp)
+            print(f'contig dirty, REASON 3 - contig lineage is not a match to genome\'s {self.match_rank}', file=report_fp)
             print(f'   contig is {pretty_print_lineage2(ctg_lin, self.match_rank)}', file=report_fp)
             print(f'   vs genome {pretty_print_lineage2(self.genome_lineage, self.match_rank)}', file=report_fp)
 

--- a/demo/provided-lineages.csv
+++ b/demo/provided-lineages.csv
@@ -1,1 +1,1 @@
-TOBG_NAT-167.fna.gz,d__Bacteria,p__Proteobacteria,c__Alphaproteobacteria,o__Rhodobacterales,f__Rhodobacteraceae,g__Salipiger,s__Salipiger thiooxidans
+TOBG_NAT-167.fna.gz,d__Bacteria,

--- a/tests/test_decontam.py
+++ b/tests/test_decontam.py
@@ -5,6 +5,7 @@ import screed
 
 from charcoal import just_taxonomy, utils
 from charcoal.lineage_db import LineageDB
+from charcoal.just_taxonomy import ContigInfo
 
 import sourmash
 from sourmash.lca import LCA_Database
@@ -433,15 +434,15 @@ def test_cleaner_gather_method_1():
 
     mh = empty_mh.copy_and_clear()
     mh.add_sequence(chunk1[0].sequence, force=True)
-    is_clean = cleaner.check_gather(chunk1[0], mh, report_fp)
-    assert not is_clean
+    clean_flag = cleaner.check_gather(chunk1[0], mh, report_fp)
+    assert clean_flag == ContigInfo.DIRTY
 
     chunk2 = load_first_chunk('tests/test-data/genomes/2.fa.gz')
 
     mh = empty_mh.copy_and_clear()
     mh.add_sequence(chunk2[0].sequence, force=True)
-    is_clean = cleaner.check_gather(chunk2[0], mh, report_fp)
-    assert is_clean
+    clean_flag = cleaner.check_gather(chunk2[0], mh, report_fp)
+    assert clean_flag == ContigInfo.CLEAN
 
 
 def test_cleaner_gather_method_1():
@@ -470,16 +471,16 @@ def test_cleaner_gather_method_1():
 
     mh = empty_mh.copy_and_clear()
     mh.add_sequence(chunk1[0].sequence, force=True)
-    is_clean = cleaner.check_gather(chunk1[0], mh, report_fp)
-    assert not is_clean
+    clean_flag = cleaner.check_gather(chunk1[0], mh, report_fp)
+    assert clean_flag == ContigInfo.DIRTY
     assert cleaner.n_reason_1 == 1
 
     chunk2 = load_first_chunk('tests/test-data/genomes/2.fa.gz')
 
     mh = empty_mh.copy_and_clear()
     mh.add_sequence(chunk2[0].sequence, force=True)
-    is_clean = cleaner.check_gather(chunk2[0], mh, report_fp)
-    assert is_clean
+    clean_flag = cleaner.check_gather(chunk2[0], mh, report_fp)
+    assert clean_flag == ContigInfo.CLEAN
     assert cleaner.n_reason_1 == 1        # should not be incremented
 
 
@@ -509,8 +510,8 @@ def test_cleaner_lca_method2_1():
 
     mh = empty_mh.copy_and_clear()
     mh.add_sequence(chunk1[0].sequence, force=True)
-    is_clean = cleaner.check_lca(chunk1[0], mh, report_fp)
-    assert not is_clean
+    clean_flag = cleaner.check_lca(chunk1[0], mh, report_fp)
+    assert clean_flag == ContigInfo.DIRTY
     print(cleaner.n_reason_1, cleaner.n_reason_2, cleaner.n_reason_3)
     assert cleaner.n_reason_3 == 1
 
@@ -518,8 +519,8 @@ def test_cleaner_lca_method2_1():
 
     mh = empty_mh.copy_and_clear()
     mh.add_sequence(chunk2[0].sequence, force=True)
-    is_clean = cleaner.check_lca(chunk2[0], mh, report_fp)
-    assert is_clean
+    clean_flag = cleaner.check_lca(chunk2[0], mh, report_fp)
+    assert clean_flag == ContigInfo.CLEAN
     assert cleaner.n_reason_3 == 1        # should not be incremented
 
 
@@ -560,7 +561,6 @@ def test_cleaner_lca_method1_1():
 
     mh = empty_mh.copy_and_clear()
     mh.add_sequence(chunk1[0].sequence, force=True)
-    is_clean = cleaner.check_lca(chunk1[0], mh, report_fp,
-                                 force_report=True)
-    assert not is_clean
+    clean_flag = cleaner.check_lca(chunk1[0], mh, report_fp, force_report=True)
+    assert clean_flag == ContigInfo.DIRTY
     assert cleaner.n_reason_2 == 1

--- a/tests/test_decontam.py
+++ b/tests/test_decontam.py
@@ -98,7 +98,7 @@ def test_choose_genome_lineage_1():
     provided_lin = ""
     f_ident = 1.0
     f_major = 1.0
-    x = just_taxonomy.choose_genome_lineage(lca_lin, provided_lin,
+    x = just_taxonomy.choose_genome_lineage(lca_lin, provided_lin, 'genus',
                                             f_ident, f_major,
                                             ReportingCapture())
     (chosen_lin, comment) = x
@@ -119,7 +119,7 @@ def test_choose_genome_lineage_2():
 
     f_ident = 1.0
     f_major = 1.0
-    x = just_taxonomy.choose_genome_lineage(lca_lin, provided_lin,
+    x = just_taxonomy.choose_genome_lineage(lca_lin, provided_lin, 'genus',
                                             f_ident, f_major,
                                             ReportingCapture())
     (chosen_lin, comment) = x
@@ -140,7 +140,7 @@ def test_choose_genome_lineage_3():
     f_ident = 1.0
     f_major = 1.0
     reporting = ReportingCapture()
-    x = just_taxonomy.choose_genome_lineage(lca_lin, provided_lin,
+    x = just_taxonomy.choose_genome_lineage(lca_lin, provided_lin, 'genus',
                                             f_ident, f_major, reporting)
     chosen_lin, comment = x
 
@@ -162,7 +162,7 @@ def test_choose_genome_lineage_4():
     f_ident = 1.0
     f_major = 1.0
     reporting = ReportingCapture()
-    x = just_taxonomy.choose_genome_lineage(lca_lin, provided_lin,
+    x = just_taxonomy.choose_genome_lineage(lca_lin, provided_lin, 'genus',
                                             f_ident, f_major, reporting)
     chosen_lin, comment = x
 
@@ -181,7 +181,7 @@ def test_choose_genome_lineage_5():
     f_ident = 0.05
     f_major = 1.0
     reporting = ReportingCapture()
-    x = just_taxonomy.choose_genome_lineage(lca_lin, provided_lin,
+    x = just_taxonomy.choose_genome_lineage(lca_lin, provided_lin, 'genus',
                                             f_ident, f_major, reporting)
     (chosen_lin, comment) = x
 
@@ -191,15 +191,13 @@ def test_choose_genome_lineage_5():
 
 
 def test_choose_genome_lineage_6():
-    # bad choice - bad lca lineage, nothing else provided
-
     lca_lin = "Bacteria;Proteobacteria;Gammaproteobacteria;Alteromonadales;Shewanellaceae;Shewanella;Shewanella baltica;Shewanella baltica OS185"
     lca_lin = make_lineage(lca_lin)
     provided_lin = ""
     f_ident = 1.0
     f_major = 0.15
     reporting = ReportingCapture()
-    x = just_taxonomy.choose_genome_lineage(lca_lin, provided_lin,
+    x = just_taxonomy.choose_genome_lineage(lca_lin, provided_lin, 'genus',
                                             f_ident, f_major, reporting)
     (chosen_lin, comment) = x
 

--- a/tests/test_decontam.py
+++ b/tests/test_decontam.py
@@ -618,3 +618,57 @@ def test_cleaner_lca_method_noident():
     assert clean_flag == ContigInfo.NO_IDENT
     assert cleaner.n_reason_2 == 0
     assert cleaner.n_reason_3 == 0
+
+
+def test_cleaner_gather_method_nohash():
+    # check lca method - no hash
+    genome_lineage = "Bacteria;Verrucomicrobia;Verrucomicrobiae;Verrucomicrobiales;Akkermansiaceae;Akkermansia;Akkermansia muciniphila"
+    genome_lineage = make_lineage(genome_lineage)
+
+    match_rank = 'genus'
+    empty_mh = sourmash.MinHash(n=0, ksize=31, scaled=10000)
+
+    lineages_csv = 'tests/test-data/test-match-lineages.csv'
+    lca_db, lin_db = make_lca_and_lineages([], lineages_csv,
+                                           empty_mh.scaled, empty_mh.ksize)
+
+    # ok! now, go for cleaning...
+    cleaner = just_taxonomy.ContigsDecontaminator(genome_lineage,
+                                                  match_rank,
+                                                  empty_mh,
+                                                  lca_db, lin_db)
+    report_fp = StringIO()
+
+    chunk1 = load_first_chunk('tests/test-data/genomes/2.fa.gz')
+    mh = empty_mh.copy_and_clear()
+    clean_flag = cleaner.check_gather(chunk1[0], mh, report_fp)
+    assert clean_flag == ContigInfo.NO_HASH
+    assert cleaner.n_reason_1 == 0
+
+
+def test_cleaner_gather_method_noident():
+    # check lca method - no matches
+    genome_lineage = "Bacteria;Verrucomicrobia;Verrucomicrobiae;Verrucomicrobiales;Akkermansiaceae;Akkermansia;Akkermansia muciniphila"
+    genome_lineage = make_lineage(genome_lineage)
+
+    match_rank = 'genus'
+    empty_mh = sourmash.MinHash(n=0, ksize=31, scaled=10000)
+
+    lineages_csv = 'tests/test-data/test-match-lineages.csv'
+    # no matches here => []
+    lca_db, lin_db = make_lca_and_lineages([], lineages_csv,
+                                           empty_mh.scaled, empty_mh.ksize)
+
+    # ok! now, go for cleaning...
+    cleaner = just_taxonomy.ContigsDecontaminator(genome_lineage,
+                                                  match_rank,
+                                                  empty_mh,
+                                                  lca_db, lin_db)
+    report_fp = StringIO()
+
+    chunk1 = load_first_chunk('tests/test-data/genomes/2.fa.gz')
+    mh = empty_mh.copy_and_clear()
+    mh.add_sequence(chunk1[0].sequence, force=True)
+    clean_flag = cleaner.check_gather(chunk1[0], mh, report_fp)
+    assert clean_flag == ContigInfo.NO_IDENT
+    assert cleaner.n_reason_1 == 0

--- a/tests/test_decontam.py
+++ b/tests/test_decontam.py
@@ -185,7 +185,7 @@ def test_choose_genome_lineage_5():
     (chosen_lin, comment) = x
 
     print(reporting.lines)
-    assert reporting.contains('Please provide a lineage for this genome')
+    assert 'provide a lineage for this genome' in comment
     assert 'too few identifiable hashes' in comment
 
 
@@ -203,7 +203,7 @@ def test_choose_genome_lineage_6():
     (chosen_lin, comment) = x
 
     print(reporting.lines)
-    assert reporting.contains('Please provide a lineage for this genome')
+    assert 'provide a lineage for this genome' in comment
     assert 'too few hashes in major lineage' in comment
 
 
@@ -472,7 +472,7 @@ def test_cleaner_gather_method_1():
     mh.add_sequence(chunk1[0].sequence, force=True)
     is_clean = cleaner.check_gather(chunk1[0], mh, report_fp)
     assert not is_clean
-    assert cleaner.n_reason_3 == 1
+    assert cleaner.n_reason_1 == 1
 
     chunk2 = load_first_chunk('tests/test-data/genomes/2.fa.gz')
 
@@ -480,7 +480,7 @@ def test_cleaner_gather_method_1():
     mh.add_sequence(chunk2[0].sequence, force=True)
     is_clean = cleaner.check_gather(chunk2[0], mh, report_fp)
     assert is_clean
-    assert cleaner.n_reason_3 == 1        # should not be incremented
+    assert cleaner.n_reason_1 == 1        # should not be incremented
 
 
 def test_cleaner_lca_method2_1():
@@ -511,7 +511,8 @@ def test_cleaner_lca_method2_1():
     mh.add_sequence(chunk1[0].sequence, force=True)
     is_clean = cleaner.check_lca(chunk1[0], mh, report_fp)
     assert not is_clean
-    assert cleaner.n_reason_2 == 1
+    print(cleaner.n_reason_1, cleaner.n_reason_2, cleaner.n_reason_3)
+    assert cleaner.n_reason_3 == 1
 
     chunk2 = load_first_chunk('tests/test-data/genomes/2.fa.gz')
 
@@ -519,7 +520,7 @@ def test_cleaner_lca_method2_1():
     mh.add_sequence(chunk2[0].sequence, force=True)
     is_clean = cleaner.check_lca(chunk2[0], mh, report_fp)
     assert is_clean
-    assert cleaner.n_reason_2 == 1        # should not be incremented
+    assert cleaner.n_reason_3 == 1        # should not be incremented
 
 
 def test_cleaner_lca_method1_1():
@@ -562,4 +563,4 @@ def test_cleaner_lca_method1_1():
     is_clean = cleaner.check_lca(chunk1[0], mh, report_fp,
                                  force_report=True)
     assert not is_clean
-    assert cleaner.n_reason_1 == 1
+    assert cleaner.n_reason_2 == 1


### PR DESCRIPTION
This PR -

* pulls almost everything back to match_rank for evaluation and reporting, which is more stringent than before;
* reorders the reason numbers so that the gather test, the first check & the most common reason for removal, is \# 1 (#50) 
* adds full contig classification per #51 to include NO_IDENT and NO_HASH, not just clean and dirty
* changes lineage display to be more informative (but now it's maybe too verbose)

TODO:
- [x] add tests for new `ContigInfo` enum and clean_flag reasoning, ref #51 
- [x] nicer lineage foo #68 

Fixes #50 #51 #68 