### PR TITLE
enable lineages csv that does not contain trailing commas

### DIFF
--- a/charcoal/Snakefile
+++ b/charcoal/Snakefile
@@ -92,7 +92,7 @@ if provided_lineages_file:
                 print(f'** ({genome_filename} not in {genome_list_file})')
                 if strict_mode:
                     sys.exit(-1)
-            if len(row[1:]) < 1:
+            if not row[1:]:
                 print(f'** cannot parse provided lineage for {genome_filename}')
                 print(f'** ; is it comma separated?')
                 sys.exit(-1)

--- a/charcoal/Snakefile
+++ b/charcoal/Snakefile
@@ -92,7 +92,7 @@ if provided_lineages_file:
                 print(f'** ({genome_filename} not in {genome_list_file})')
                 if strict_mode:
                     sys.exit(-1)
-            if len(row[1:]) <= 1:
+            if len(row[1:]) < 1:
                 print(f'** cannot parse provided lineage for {genome_filename}')
                 print(f'** ; is it comma separated?')
                 sys.exit(-1)

--- a/demo/provided-lineages.csv
+++ b/demo/provided-lineages.csv
@@ -1,1 +1,1 @@
-TOBG_NAT-167.fna.gz,d__Bacteria,
+TOBG_NAT-167.fna.gz,d__Bacteria


### PR DESCRIPTION
If the lineages csv does not have a trailing comma:
`GCF_000317415.1.fna.gz,d__Eukaryota` vs `GCF_000317415.1.fna.gz,d__Eukaryota,`
 it is not interpreted as a proper lineages file.


error:
```
charcoal run orthodb/orthodb.conf -n
** cannot parse provided lineage for GCF_000317415.1.fna.gz
** ; is it comma separated?
SystemExit in line 98 of /home/ntpierce/charcoal/charcoal/Snakefile:
-1
  File "/home/ntpierce/charcoal/charcoal/Snakefile", line 98, in <module>
Error in snakemake invocation: Command '['snakemake', '-s', '/home/ntpierce/charcoal/charcoal/Snakefile', '--use-conda', '-j', '1', '-n', '--configfile', '/home/ntpierce/charcoal/charcoal/conf/defaults.conf', '/home/ntpierce/charcoal/charcoal/conf/system.conf', 'orthodb/orthodb.conf']' returned non-zero exit status 1.
```

switching line 95 `if len(row[1:]) <= 1:` to `if len(row[1:]) < 1:` fixes.

