### PR TITLE
add direct nucmer and mashmap subcommands to alignplot

### DIFF
--- a/charcoal/alignplot.py
+++ b/charcoal/alignplot.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 """
 Code to produce a stacked dotplot and alignment slope diagram.
 """


### PR DESCRIPTION
Usage:

## run and plot a nucmer comparison
```
python -m charcoal.alignplot nucmer ibd-genomes-2/ZeeviD_2015__PNP_Main_232__bin.27.fa.gz genbank_genomes/GCF_003481565.1_genomic.fna.gz -o xyz
```

## run and plot a mashmap comparison
```
python -m charcoal.alignplot mashmap ibd-genomes-2/ZeeviD_2015__PNP_Main_232__bin.27.fa.gz genbank_genomes/GCF_003481565.1_genomic.fna.gz -o xyz
```