### PR TITLE
[MRG] update snakemake and other dependencies

### DIFF
--- a/charcoal/conf/env-reporting.yml
+++ b/charcoal/conf/env-reporting.yml
@@ -9,8 +9,8 @@ dependencies:
     - notebook>=6,<7
     - plotly>=4.9.0,<5
     - ipykernel
+    - sourmash>=4.1.1,<5
     - pip
     - pip:
       - git+https://github.com/dib-lab/charcoal.git
-      - sourmash>=4.1.0,<5
       - pyinterval

--- a/charcoal/conf/env-sourmash.yml
+++ b/charcoal/conf/env-sourmash.yml
@@ -8,8 +8,8 @@ dependencies:
     - pytest>6,<7
     - pytest-dependency>=0.5.1
     - pyyaml>5.3,<6
+    - sourmash>=4.1.1,<5
     - pip
     - pip:
       - git+https://github.com/dib-lab/charcoal.git
-      - sourmash>=4.1.0,<5
       - pyinterval

--- a/environment.yml
+++ b/environment.yml
@@ -4,10 +4,9 @@ channels:
     - bioconda
     - defaults
 dependencies:
-    - python>=3.6
-    - snakemake-minimal=5.8.1
+    - python>=3.7
+    - snakemake-minimal=6.4.1
     - screed
     - click
     - pip
-    - pip:
-      - sourmash>=4.1.0,<5
+    - sourmash>=4.1.1,<5

--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ dependencies:
     - python>=3.7
     - snakemake-minimal=6.4.1
     - screed
-    - click
+    - click>=7,<8
     - pip
+    - mamba
     - sourmash>=4.1.1,<5

--- a/setup.py
+++ b/setup.py
@@ -33,5 +33,5 @@ setup(
     setup_requires = [ "setuptools>=38.6.0",
                        'setuptools_scm', 'setuptools_scm_git_archive' ],
     use_scm_version = {"write_to": "charcoal/version.py"},
-    install_requires = ['snakemake==6.4.1', 'click>7<8']
+    install_requires = ['snakemake==6.4.1', 'click>=7,<8']
 )

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,9 @@ CLASSIFIERS = [
     "Natural Language :: English",
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS :: MacOS X",
-    "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
 
@@ -31,5 +33,5 @@ setup(
     setup_requires = [ "setuptools>=38.6.0",
                        'setuptools_scm', 'setuptools_scm_git_archive' ],
     use_scm_version = {"write_to": "charcoal/version.py"},
-    install_requires = ['snakemake>=5.10', 'click>=7']
+    install_requires = ['snakemake==6.4.1', 'click>7<8']
 )


### PR DESCRIPTION
Updates python to >= 3.7, pins snakemake to 6.4.1, and click to <8. Also adds `mamba` to the default install. Reconciles setup.py and environment.yml.

Addresses problems discovered in https://github.com/dib-lab/charcoal/issues/182, among other things.

