### PR TITLE
[WIP] update snakemake version

### DIFF
--- a/charcoal/genbank_genomes.py
+++ b/charcoal/genbank_genomes.py
@@ -20,6 +20,8 @@ def url_for_accession(accession):
     number = "/".join([number[p : p + 3] for p in range(0, len(number), 3)])
     url = f"ftp://ftp.ncbi.nlm.nih.gov/genomes/all/{db}/{number}"
 
+    print(f'downloading genome from: {url}')
+
     with urllib.request.urlopen(url) as response:
         all_names = response.read()
 

--- a/environment.yml
+++ b/environment.yml
@@ -4,8 +4,8 @@ channels:
     - bioconda
     - defaults
 dependencies:
-    - python>=3.7
-    - snakemake-minimal=6.4.1
+    - python>=3.7,<3.10
+    - snakemake-minimal==6.10.0
     - screed
     - click>=7,<8
     - pip

--- a/setup.py
+++ b/setup.py
@@ -33,5 +33,5 @@ setup(
     setup_requires = [ "setuptools>=38.6.0",
                        'setuptools_scm', 'setuptools_scm_git_archive' ],
     use_scm_version = {"write_to": "charcoal/version.py"},
-    install_requires = ['snakemake==6.4.1', 'click>=7,<8']
+    install_requires = ['snakemake==6.10.0', 'click>=7,<8']
 )


### PR DESCRIPTION
This PR updates snakemake to 6.10.0.

There are a few other misc changes -
- limit Python to < 3.10 for now
- add a print statement that makes genome download clearer

Maybe TODO:
- [ ] update sourmash to 4.2.2 (?)
- [ ] switch to using sourmash sketch rather than sourmash compute
